### PR TITLE
Cheap fix for #22

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -80,7 +80,7 @@ Renderer.prototype.getFile = function *(file) {
 Renderer.prototype.compileTemplate = function *(file) {
   var meta = yield this.getFile(file);
   debug("compiling template %s", chalk.grey(path.relative(this.options.root, file)));
-  meta.fn = this.handlebars.compile(meta.body);
+  meta.fn = this.handlebars.compile(meta.body, this.compileOptions);
   meta.render = function (locals, options) {
     return this.fn(locals, options);
   };
@@ -285,9 +285,9 @@ Renderer.prototype.helper = function (name, fn) {
  */
 Renderer.prototype.render = function *(template, locals, options) {
   var o = this.options;
-
   locals = extend(true, {}, locals);
   options = extend(true, {}, { data: o.data }, options);
+  this.compileOptions = options;
   debug("rendering %s template", chalk.underline(template));
 
   // extract layout id


### PR DESCRIPTION
The quickest/dirtiest way of fixing #22 is to hold those options passed
on this.render on the instance, then use them when `handlebars.compile`
is calling `compileTemplate`.
